### PR TITLE
Minor bug fix for when there is no parc file

### DIFF
--- a/wauwterpreproc.py
+++ b/wauwterpreproc.py
@@ -224,8 +224,9 @@ def layersmooth(niifile,layfile,fwhm=1,kernelsize=7,nlay=6,parcfile='',lowcut=10
     if parcfile != '':
         parc,hdrparc=readnii(parcfile,scaling=False)
         mask*=parc.astype(np.int16)
+        del parc
     mask=np.reshape(mask,nvox)
-    del parc
+    
 
     layz=np.max(lay)
     lay=np.ceil(lay/(layz/float(nlay)))


### PR DESCRIPTION
Move 'del parc' command under the 'if parc' statement, to stop UnboundLocalError when no parc file is given.